### PR TITLE
Debian10 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - DOCKER_TAG=alpine-3.5-glibc
   - DOCKER_TAG=debian-8
   - DOCKER_TAG=debian-9
+  - DOCKER_TAG=debian-10
   - DOCKER_TAG=ubuntu-16.04
   - DOCKER_TAG=ubuntu-18.04
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -35,8 +35,8 @@ RUN \
     add-pkg --virtual build-dependencies curl ca-certificates gnupg && \
     . /etc/os-release && \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key --keyring /etc/apt/trusted.gpg.d/nodesource.gpg add - && \
-    echo "deb http://deb.nodesource.com/node_8.x $VERSION_CODENAME main" > /etc/apt/sources.list.d/nodesource.list && \
-    echo "deb-src http://deb.nodesource.com/node_8.x $VERSION_CODENAME main" >> /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb http://deb.nodesource.com/node_12.x $VERSION_CODENAME main" > /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb-src http://deb.nodesource.com/node_12.x $VERSION_CODENAME main" >> /etc/apt/sources.list.d/nodesource.list && \
     # Cleanup
     del-pkg build-dependencies && \
     rm -rf /tmp/* /tmp/.[!.]*

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Different docker images are available:
 | [Alpine 3.10]       | alpine-3.10-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.10-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.10-glibc "Get your own image badge on microbadger.com") |
 | [Debian 8]         | debian-8         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:debian-8.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:debian-8/ "Get your own image badge on microbadger.com") |
 | [Debian 9]         | debian-9         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:debian-9.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:debian-9/ "Get your own image badge on microbadger.com") |
+| [Debian 10]         | debian-10         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:debian-10.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:debian-10/ "Get your own image badge on microbadger.com") |
 | [Ubuntu 16.04 LTS] | ubuntu-16.04     | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:ubuntu-16.04.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:ubuntu-16.04 "Get your own image badge on microbadger.com") |
 | [Ubuntu 18.04 LTS] | ubuntu-18.04     | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:ubuntu-18.04.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:ubuntu-18.04 "Get your own image badge on microbadger.com") |
 
@@ -75,6 +76,7 @@ Different docker images are available:
 [Alpine 3.10]: https://alpinelinux.org
 [Debian 8]: https://www.debian.org/releases/jessie/
 [Debian 9]: https://www.debian.org/releases/stretch/
+[Debian 10]: https://www.debian.org/releases/buster/
 [Ubuntu 16.04 LTS]: http://releases.ubuntu.com/16.04/
 [Ubuntu 18.04 LTS]: http://releases.ubuntu.com/18:04/
 

--- a/versions/debian-10
+++ b/versions/debian-10
@@ -1,0 +1,2 @@
+DOCKERFILE=Dockerfile.debian
+BASEIMAGE=jlesage/baseimage:debian-10-v2.4.3


### PR DESCRIPTION
Since you just accepted [this merge request](https://github.com/jlesage/docker-baseimage/pull/7).

Those are the changes for the docker-baseimage-gui. Again, not much has been changed.

I changed the nodejs version to 12.x from 10.x. As it´s the latest LTS release. I have tested this with debian10 and debian9, but not with debian8 and the ubuntu versions of the image.
The version of npm that debian10 installs per default is unsupported with nodejs 10.x.