### PR TITLE
Enable optionally serving applications under subpath/path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ to the `docker run` command.
 |`VNC_PASSWORD`| Password needed to connect to the application's GUI.  See the [VNC Password](#vnc-password) section for more details. | (unset) |
 |`X11VNC_EXTRA_OPTS`| Extra options to pass to the x11vnc server running in the Docker container.  **WARNING**: For advanced users. Do not use unless you know what you are doing. | (unset) |
 |`ENABLE_CJK_FONT`| When set to `1`, open-source computer font `WenQuanYi Zen Hei` is installed.  This font contains a large range of Chinese/Japanese/Korean characters. | `0` |
+|`PATH_PREFIX`| Sets the path prefix under which the application can be served. Example: `PATH_PREFIX=/path/to/app` enables accessing the app via `example.com/path/to/app/` | (unset) |
+
 
 ## Config Directory
 Inside the container, the application's configuration should be stored in the

--- a/rootfs/defaults/default_site.conf
+++ b/rootfs/defaults/default_site.conf
@@ -22,6 +22,11 @@ server {
 
 	root /opt/novnc;
 	index index.html;
+	
+	# Support serving application under path prefix.
+	location /sed_path_prefix {
+		rewrite ^/sed_path_prefix(.*)$ $1 last;
+	}
 
 	location /websockify {
 		proxy_pass http://127.0.0.1:5950;

--- a/rootfs/etc/cont-init.d/10-nginx.sh
+++ b/rootfs/etc/cont-init.d/10-nginx.sh
@@ -15,6 +15,11 @@ if ! ifconfig -a | grep -wq inet6; then
     sed-patch '/^[\t]listen \[::\]:5800 /d' /etc/nginx/default_site.conf
 fi
 
+# If environment Variable PATH_PREFIX is defined, replace it in virtual server configuration.
+if [[ ! -z "${PATH_PREFIX:-}" ]]; then
+	sed-patch "s|/sed_path_prefix|$PATH_PREFIX|g" /etc/nginx/default_site.conf
+fi
+
 # Make sure required directories exist.
 s6-setuidgid $USER_ID:$GROUP_ID mkdir -p /config/log/nginx
 


### PR DESCRIPTION
By adding an alias to the nginx default site configuration we can define an environment variable `PATH_PREFIX ` that enables the application to be accessed by the provided value.

The change is very small and simple, I also extended the docs accordingly. 
If it is bothersome that the app can be accessed in two paths now when left unconfigured namely by root `example.com:5800/` & the default unconfigured path `example.com:5800/sed_path_prefix/`, then I can simply comment the lines out and remove the comments when the ENV is set.

This PR consists of three commits I'd like to have squashed into one. 

ps: this is my first merge request on github pls tell me if I need to fix anything.