### PR TITLE
Add support for images based on Alpine 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   global:
   - DOCKER_REPO=jlesage/baseimage-gui
   matrix:
+  - DOCKER_TAG=alpine-3.13
+  - DOCKER_TAG=alpine-3.13-glibc
   - DOCKER_TAG=alpine-3.12
   - DOCKER_TAG=alpine-3.12-glibc
   - DOCKER_TAG=alpine-3.11

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -10,8 +10,8 @@ ARG BASEIMAGE=unknown
 FROM ${BASEIMAGE}
 
 # Define software versions.
-ARG LIBVNCSERVER_VERSION=9029b86
-ARG X11VNC_VERSION=29597a9
+ARG LIBVNCSERVER_VERSION=0.9.13-r1
+ARG X11VNC_VERSION=0.9.16-r2
 ARG STUNNEL_VERSION=5.44
 ARG NOVNC_VERSION=fa559b3
 ARG BOOTSTRAP_VERSION=3.3.7
@@ -20,8 +20,6 @@ ARG JQUERY_VERSION=3.2.1
 ARG JQUERY_UI_TOUCH_PUNCH_VERSION=4bc0091
 
 # Define software download URLs.
-ARG LIBVNCSERVER_URL=https://github.com/jlesage/libvncserver/archive/${LIBVNCSERVER_VERSION}.tar.gz
-ARG X11VNC_URL=https://github.com/jlesage/x11vnc/archive/${X11VNC_VERSION}.tar.gz
 ARG STUNNEL_URL=https://www.usenix.org.uk/mirrors/stunnel/archive/5.x/stunnel-${STUNNEL_VERSION}.tar.gz
 ARG NOVNC_URL=https://github.com/jlesage/novnc/archive/${NOVNC_VERSION}.tar.gz
 ARG BOOTSTRAP_URL=https://github.com/twbs/bootstrap/releases/download/v${BOOTSTRAP_VERSION}/bootstrap-${BOOTSTRAP_VERSION}-dist.zip
@@ -31,52 +29,6 @@ ARG JQUERY_UI_TOUCH_PUNCH_URL=https://raw.github.com/furf/jquery-ui-touch-punch/
 
 # Define working directory.
 WORKDIR /tmp
-
-# Compile x11vnc.
-RUN \
-    add-pkg --virtual build-dependencies \
-            curl \
-            build-base \
-            autoconf \
-            automake \
-            libtool \
-            libx11-dev \
-            libxtst-dev \
-            libjpeg-turbo-dev \
-            libpng-dev \
-            libxinerama-dev \
-            libxdamage-dev \
-            libxcomposite-dev \
-            libxcursor-dev \
-            libxrandr-dev \
-            libxfixes-dev \
-            libice-dev \
-            && \
-    # Download sources
-    mkdir libvncserver x11vnc && \
-    curl -sS -L ${LIBVNCSERVER_URL} | tar -xz --strip 1 -C libvncserver && \
-    curl -sS -L ${X11VNC_URL} | tar -xz --strip 1 -C x11vnc && \
-    # Compile libvncserver
-    cd libvncserver && \
-    ./autogen.sh --prefix=/tmp/install && \
-    make install && \
-    cd .. && \
-    # Compile x11vnc
-    cd x11vnc && \
-    autoreconf -v --install && \
-    PKG_CONFIG_PATH=/tmp/install/lib/pkgconfig/ ./configure --prefix=/tmp/install --with-websockets && \
-    make install && \
-    cd .. && \
-    # Install libraries
-    strip install/lib/libvnc*.so && \
-    cp -P install/lib/libvncserver.so* /usr/lib/ && \
-    cp -P install/lib/libvncclient.so* /usr/lib/ && \
-    # Install binaries
-    strip install/bin/x11vnc && \
-    cp install/bin/x11vnc /usr/bin/ && \
-    # Cleanup
-    del-pkg build-dependencies && \
-    rm -rf /tmp/* /tmp/.[!.]*
 
 # Compile stunnel
 RUN \
@@ -104,6 +56,8 @@ RUN \
 # Install packages.
 RUN \
     add-pkg \
+        x11vnc=${X11VNC_VERSION} \
+        libvncserver=${LIBVNCSERVER_VERSION} \
         # X11 VNC server dependencies
         openssl \
         libxtst \
@@ -174,7 +128,6 @@ RUN \
 RUN \
     add-pkg nginx && \
     rm /etc/nginx/nginx.conf \
-       /etc/init.d/nginx \
        /etc/logrotate.d/nginx \
        && \
     rm -r /etc/nginx/conf.d \

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Different docker images are available:
 | [Alpine 3.10]      | alpine-3.10      | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.10.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.10 "Get your own image badge on microbadger.com") |
 | [Alpine 3.11]      | alpine-3.11      | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.11.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.11 "Get your own image badge on microbadger.com") |
 | [Alpine 3.12]      | alpine-3.12      | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.12.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.12 "Get your own image badge on microbadger.com") |
+| [Alpine 3.13]      | alpine-3.13      | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.13.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.13 "Get your own image badge on microbadger.com") |
 | [Alpine 3.5]       | alpine-3.5-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.5-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.5-glibc "Get your own image badge on microbadger.com") |
 | [Alpine 3.6]       | alpine-3.6-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.6-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.6-glibc "Get your own image badge on microbadger.com") |
 | [Alpine 3.7]       | alpine-3.7-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.7-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.7-glibc "Get your own image badge on microbadger.com") |
@@ -66,6 +67,7 @@ Different docker images are available:
 | [Alpine 3.10]       | alpine-3.10-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.10-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.10-glibc "Get your own image badge on microbadger.com") |
 | [Alpine 3.11]       | alpine-3.11-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.11-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.11-glibc "Get your own image badge on microbadger.com") |
 | [Alpine 3.12]       | alpine-3.12-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.12-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.12-glibc "Get your own image badge on microbadger.com") |
+| [Alpine 3.13]       | alpine-3.13-glibc | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:alpine-3.13-glibc.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:alpine-3.13-glibc "Get your own image badge on microbadger.com") |
 | [Debian 8]         | debian-8         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:debian-8.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:debian-8/ "Get your own image badge on microbadger.com") |
 | [Debian 9]         | debian-9         | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:debian-9.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:debian-9/ "Get your own image badge on microbadger.com") |
 | [Debian 10]        | debian-10        | [![](https://images.microbadger.com/badges/image/jlesage/baseimage-gui:debian-10.svg)](http://microbadger.com/#/images/jlesage/baseimage-gui:debian-10/ "Get your own image badge on microbadger.com") |
@@ -80,6 +82,7 @@ Different docker images are available:
 [Alpine 3.10]: https://alpinelinux.org
 [Alpine 3.11]: https://alpinelinux.org
 [Alpine 3.12]: https://alpinelinux.org
+[Alpine 3.13]: https://alpinelinux.org
 [Debian 8]: https://www.debian.org/releases/jessie/
 [Debian 9]: https://www.debian.org/releases/stretch/
 [Debian 10]: https://www.debian.org/releases/buster/

--- a/versions/alpine-3.13
+++ b/versions/alpine-3.13
@@ -1,0 +1,2 @@
+DOCKERFILE=Dockerfile.alpine
+BASEIMAGE=jlesage/baseimage:alpine-3.13-v2.4.5

--- a/versions/alpine-3.13-glibc
+++ b/versions/alpine-3.13-glibc
@@ -1,0 +1,2 @@
+DOCKERFILE=Dockerfile.alpine
+BASEIMAGE=jlesage/baseimage:alpine-3.13-glibc-v2.4.5


### PR DESCRIPTION
Hi,

I'm not sure why you choose to build x11vnc and libvncserver from source and doing so with the versions from your archive on alpine 3.13 currently fails (see https://github.com/LibVNC/x11vnc/issues/128).

Using the Alpine version of both worked fine for me, though.