### PR TITLE
Add RSA signing keys for untrusted installation of CJK font, fix #39

### DIFF
--- a/rootfs/etc/cont-init.d/10-cjk-font.sh
+++ b/rootfs/etc/cont-init.d/10-cjk-font.sh
@@ -10,6 +10,7 @@ if [ "${ENABLE_CJK_FONT:-0}" -eq 1 ]; then
     else
         echo "installing CJK font..."
         if [ -n "$(which apk)" ]; then
+            apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.16/main -u alpine-keys
             add-pkg wqy-zenhei --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing 2>&1
         else
             add-pkg fonts-wqy-zenhei 2>&1


### PR DESCRIPTION
The installation of CJK font has error:

`
[cont-init.d] 10-cjk-font.sh: installing CJK font...
[cont-init.d] 10-cjk-font.sh: fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
[cont-init.d] 10-cjk-font.sh: WARNING: Ignoring http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz: UNTRUSTED signature
`

Applying this can fix the issues, https://alpinelinux.org/posts/Alpine-edge-signing-keys-rotated.html

Will also PR you on the master branch