### PR TITLE
Forward full desktop notification payload

### DIFF
--- a/rootfs/opt/noVNC/app/notificationService.js
+++ b/rootfs/opt/noVNC/app/notificationService.js
@@ -102,9 +102,13 @@ const NotificationService = (function() {
     function handleWebSocketMessage(event) {
         const data = msgpack.decode(new Uint8Array(event.data));
 
-        Log.Debug("Received message: " + JSON.stringify(data));
+        const hintNames = data.hints && typeof data.hints === 'object'
+            ? Object.keys(data.hints)
+            : [];
 
-        if (!data.summary || !data.body) {
+        Log.Debug(`Received notification: id=${data.id}, app=${data.appName}, summary=${data.summary}, hints=${hintNames.join(',')}`);
+
+        if (typeof data.summary !== 'string' || typeof data.body !== 'string') {
             Log.Error("Received invalid notification data.");
             return;
         }
@@ -113,7 +117,7 @@ const NotificationService = (function() {
             new Notification(data.summary, {
                 body: data.body,
                 icon: "app/images/icons/master_icon.png?v=UNIQUE_VERSION",
-                tag: data.replacesID ? `id_${data.replacesID}` : undefined,
+                tag: data.id ? `id_${data.id}` : undefined,
             });
         } else {
             Log.Info('Notification permission has been removed.');

--- a/src/webservices/notification.go
+++ b/src/webservices/notification.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -18,13 +19,20 @@ import (
 // Notifications implements the org.freedesktop.Notifications D-Bus interface.
 // https://specifications.freedesktop.org/notification-spec/1.2/protocol.html
 type Notifications struct {
-	nextID uint32
+	nextID atomic.Uint32
 }
 
 // Message represents the structure of WebSocket messages sent to clients.
 type NotificationMessage struct {
-	Summary string `msgpack:"summary"`
-	Body    string `msgpack:"body"`
+	ID            uint32         `msgpack:"id"`
+	AppName       string         `msgpack:"appName"`
+	ReplacesID    uint32         `msgpack:"replacesID"`
+	AppIcon       string         `msgpack:"appIcon"`
+	Summary       string         `msgpack:"summary"`
+	Body          string         `msgpack:"body"`
+	Actions       []string       `msgpack:"actions"`
+	Hints         map[string]any `msgpack:"hints"`
+	ExpireTimeout int32          `msgpack:"expireTimeout"`
 }
 
 // WebSocket clients
@@ -47,7 +55,7 @@ func notificationServiceInit(appCtx context.Context) error {
 	}
 
 	// Register org.freedesktop.Notifications.
-	n := &Notifications{nextID: 0}
+	n := &Notifications{}
 	err = conn.Export(n, "/org/freedesktop/Notifications", "org.freedesktop.Notifications")
 	if err != nil {
 		conn.Close()
@@ -214,17 +222,32 @@ func notificationWebsocketHandler(appCtx context.Context, w http.ResponseWriter,
 
 // Notify handles the org.freedesktop.Notifications.Notify method.
 func (n *Notifications) Notify(appName string, replacesID uint32, appIcon, summary, body string, actions []string, hints map[string]dbus.Variant, expireTimeout int32) (uint32, *dbus.Error) {
-	// Create notification message.
-	message := NotificationMessage{
-		Summary: summary,
-		Body:    body,
-	}
-
 	// Assign a new ID if replacesID is 0.
 	id := replacesID
 	if id == 0 {
-		n.nextID++
-		id = n.nextID
+		id = n.nextID.Add(1)
+		if id == 0 {
+			id = n.nextID.Add(1)
+		}
+	}
+
+	// Unwrap D-Bus variants so their values can be encoded with MessagePack.
+	plainHints := make(map[string]any, len(hints))
+	for name, hint := range hints {
+		plainHints[name] = hint.Value()
+	}
+
+	// Create notification message.
+	message := NotificationMessage{
+		ID:            id,
+		AppName:       appName,
+		ReplacesID:    replacesID,
+		AppIcon:       appIcon,
+		Summary:       summary,
+		Body:          body,
+		Actions:       actions,
+		Hints:         plainHints,
+		ExpireTimeout: expireTimeout,
 	}
 
 	clientsMutex.Lock()

--- a/src/webservices/notification_test.go
+++ b/src/webservices/notification_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestNotifyForwardsFullPayload(t *testing.T) {
+	ch := make(chan NotificationMessage, 1)
+	clientsMutex.Lock()
+	clients[nil] = ch
+	clientsMutex.Unlock()
+	t.Cleanup(func() {
+		clientsMutex.Lock()
+		delete(clients, nil)
+		clientsMutex.Unlock()
+	})
+
+	pixels := []byte{0x11, 0x22, 0x33, 0xff}
+	hints := map[string]dbus.Variant{
+		"desktop-entry": dbus.MakeVariant("firefox"),
+		"image-data":    dbus.MakeVariant(pixels),
+	}
+	n := &Notifications{}
+	id, dbusErr := n.Notify(
+		"Firefox",
+		0,
+		"firefox",
+		"Example title",
+		"Example body",
+		[]string{"default", "Activate"},
+		hints,
+		5000,
+	)
+	if dbusErr != nil {
+		t.Fatalf("Notify returned a D-Bus error: %v", dbusErr)
+	}
+
+	message := <-ch
+	want := NotificationMessage{
+		ID:            1,
+		AppName:       "Firefox",
+		AppIcon:       "firefox",
+		Summary:       "Example title",
+		Body:          "Example body",
+		Actions:       []string{"default", "Activate"},
+		Hints:         map[string]any{"desktop-entry": "firefox", "image-data": pixels},
+		ExpireTimeout: 5000,
+	}
+	if id != want.ID {
+		t.Fatalf("Notify returned ID %d, want %d", id, want.ID)
+	}
+	if !reflect.DeepEqual(message, want) {
+		t.Fatalf("forwarded message = %#v, want %#v", message, want)
+	}
+
+	encoded, err := msgpack.Marshal(message)
+	if err != nil {
+		t.Fatalf("marshal notification: %v", err)
+	}
+	var decoded NotificationMessage
+	if err := msgpack.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal notification: %v", err)
+	}
+	if !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("decoded message = %#v, want %#v", decoded, want)
+	}
+}


### PR DESCRIPTION
## Summary

- forward the assigned ID and every `Notify` argument to WebSocket clients
- unwrap D-Bus hint variants so values such as raw image bytes remain MessagePack-encodable
- use the assigned ID for browser notification replacement and avoid logging binary hint contents
- allocate notification IDs atomically because exported D-Bus methods may run concurrently

Existing `summary` and `body` keys remain unchanged.

## Tests

- `go test ./...`
- `node --check rootfs/opt/noVNC/app/notificationService.js`